### PR TITLE
fix: use new tag for release

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -35,17 +35,15 @@ jobs:
           branch: main
           patchAll: true
       - name: Push tag
+        id: push_tag
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.semver.outputs.nextStrict }}
-      - name: Checkout code
-        uses: actions/checkout@v3
       - name: Create release
         uses: actions/create-release@v1
         env:
-          # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ steps.push_tag.outputs.new_tag }}
+          release_name: ${{ steps.push_tag.outputs.new_tag }}


### PR DESCRIPTION
Since the release is no longer triggered by tag push, it doesn't automatically have the tag as it's git ref.